### PR TITLE
Change example values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
                 <interfaceOnly>true</interfaceOnly>
                 <useSpringBoot3>true</useSpringBoot3>
                 <useSpringController>true</useSpringController>
-<!--                <useOneOfInterfaces>true</useOneOfInterfaces>-->
+                <useOneOfInterfaces>true</useOneOfInterfaces> <!-- whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface -->
                 <legacyDiscriminatorBehavior>false</legacyDiscriminatorBehavior>
                 <skipDefaultInterface>true</skipDefaultInterface>
                 <apiPackage>be.belgium.gcloud.rest.reference.api</apiPackage> <!-- change to Java package for your project -->

--- a/src/main/openapi/cloudevents/v1/cloudevents-v1.yaml
+++ b/src/main/openapi/cloudevents/v1/cloudevents-v1.yaml
@@ -91,16 +91,6 @@ components:
           x-ignore-rules:
             jsn-null: allow null to comply with CloudEvents 1.0 spec
       required: [ id, type, service, specversion, source ]
-      example:
-        {
-          "specversion": "1.0",
-          "id": "550e8400-e29b-41d4-a716-446655440000",
-          "service": "be.belgif.example.meeting.v3",
-          "type": "be.belgif.example.meeting.v3.meetings.create",
-          "source": "urn:async-source:client:123",
-          "subject": "132456",
-          "data": { "...": "..." }
-        }
 
     AsynchronousMessage:
       description: An asynchronous message represented using the [CloudEvents standard](https://github.com/cloudevents/spec).
@@ -162,6 +152,16 @@ components:
 #              jsn-null: allow null to comply with CloudEvents 1.0 spec
       x-ignore-rules:
         jsn-naming: allow underscore in data_base64 property in order to comply with the CloudEvents standard
+      example:
+        {
+          "specversion": "1.0",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "service": "be.belgif.example.meeting.v3",
+          "type": "be.belgif.example.meeting.v3.meetings.create",
+          "source": "urn:async-source:client:123",
+          "subject": "132456",
+          "data": { "...": "..." }
+        }
 
     AsynchronousReplyMessageBase:
       description: Context attributes for reply messages
@@ -173,23 +173,13 @@ components:
               description: The `id` of the corresponding request message
               type: string
               minLength: 1
+              example: "550e8400-e29b-41d4-a716-446655440000"
             relatedtosource:
               description: The `source` of the corresponding request message
               type: string
               minLength: 1
+              example: "urn:async-source:client:123"
           required: [relatedto, relatedtosource]
-      example:
-        {
-          "specversion": "1.0",
-          "id": "123ef800-e29b-41d4-a716-546655440001",
-          "service": "be.belgif.example.meeting.v3",
-          "source": "urn:async-source:be.belgif.example",
-          "type": "be.belgif.example.meeting.v3.meetings.create.reply",
-          "relatedto": "550e8400-e29b-41d4-a716-446655440000",
-          "relatedtosource": "urn:async-source:client:123",
-          "subject": "132456",
-          "data": { "...": "..." }
-        }
 
     AsynchronousProblemReplyMessage:
       description: An asynchronous problem reply message

--- a/src/test/resources/meeting-asyncapi-merged-temp.yaml
+++ b/src/test/resources/meeting-asyncapi-merged-temp.yaml
@@ -1,0 +1,442 @@
+asyncapi: 3.0.0
+### This AsyncAPI uses merged schemas in 'AsyncAPI' variant instead of OpenAPI to work around bug https://github.com/asyncapi/openapi-schema-parser/issues/275
+info:
+  title: Meeting
+  version: 3.7.1
+  description: |
+    The meeting API allows you to manage meetings and get notifications upon meeting changes.
+    This is an example API description to demonstrate using AsyncAPI for asynchronous messaging compliant with the Belgif guide.
+defaultContentType: application/json
+servers:
+  artemisJmsBroker:
+    #jms bindings from https://github.com/asyncapi/bindings/tree/master/jms#server
+    host: 'my-broker:1234'
+    protocol: jms
+    description: The broker accessed via JMS.
+    bindings:
+      jms:
+        jmsConnectionFactory: org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory
+channels:
+  MeetingSendChannel:
+    summary: Channel to send meeting-related messages
+    address: be.belgif.example.meeting.v3.sendQueue
+    messages:
+      "be.belgif.example.meeting.v3.meetings.create":
+        $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.create'
+  MeetingReceiveChannel:
+    summary: Channel to receive meeting-related messages
+    address: be.belgif.example.meeting.v3.receiveQueue
+    messages: # AsyncAPI spec defines that "Every message sent to this channel MUST be valid against one, and only one, of the message objects defined in this map."
+      "be.belgif.example.meeting.v3.meetings.create.reply":
+        $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.create.reply'
+      "be.belgif.example.meeting.v3.meetings.create.problemReply":
+        $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.create.problemReply'
+      "be.belgif.example.meeting.v3.meetings.notify.invited":
+        $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.notify.invited'
+      "be.belgif.example.meeting.v3.meetings.notify.canceled":
+        $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.notify.canceled'
+operations:
+  # the messages referenced by each operation MUST be part of the list of messages on the channel used by the operation
+  # if omitted, the operation is expected to accept any message allowed on the channel
+  createMeeting:
+    summary: "Create a meeting"
+    action: send
+    channel:
+      $ref: '#/channels/MeetingSendChannel'
+    messages:
+      - $ref: '#/channels/MeetingSendChannel/messages/be.belgif.example.meeting.v3.meetings.create'
+    reply:
+      channel:
+        $ref: '#/channels/MeetingReceiveChannel'
+      messages:
+        - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.create.reply'
+        - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.create.problemReply'
+  notifyMeetingInvited:
+    summary: "Receive notification that you were invited to a meeting"
+    action: receive
+    channel:
+      $ref: '#/channels/MeetingReceiveChannel'
+    messages:
+      - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.notify.invited'
+  notifyMeetingCanceled:
+    summary: "Receive notification that a meeting was canceled"
+    action: receive
+    channel:
+      $ref: '#/channels/MeetingReceiveChannel'
+    messages:
+      - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.notify.canceled'
+components:
+  messages:
+    "be.belgif.example.meeting.v3.meetings.create":
+      title: be.belgif.example.meeting.v3.meetings.create
+      description: Request to create a meeting
+      payload:
+        schema:
+          $ref: '#/components/schemas/CreateMeetingMessage'
+      examples:
+        - payload:  # TODO: duplicate example from schema bc example is empty otherwise in viewer
+            {
+              "specversion": "1.0",
+              "id": "550e8400-e29b-41d4-a716-446655440000",
+              "service": "be.belgif.example.meeting.v3",
+              "type": "be.belgif.example.meeting.v3.meetings.create",
+              "source": "urn:async-source:client:123",
+              "subject": "132456",
+              "data": {
+                "invitees": ["123", "456"],
+                "period": {
+                  "start": "2025-10-06T13:30:00+02:00",
+                  "end": "2025-10-06T14:30:00+02:00"
+                }
+              }
+            }
+    "be.belgif.example.meeting.v3.meetings.create.reply":
+      payload:
+        schema:
+          $ref: '#/components/schemas/CreateMeetingReplyMessage'
+    "be.belgif.example.meeting.v3.meetings.create.problemReply":
+      payload:
+        schema:
+          $ref: '#/components/schemas/AsynchronousProblemReplyMessage'
+      examples:
+        - payload: 
+            {
+              "specversion": "1.0",
+              "id": "987654-1234-1235-4567489798",
+              "service": "be.belgif.example.meeting.v3",
+              "source": "urn:async-source:be.belgif.example",
+              "type": "be.belgif.example.meeting.v3.meetings.create.problemReply",
+              "datacontenttype": "application/problem+json",
+              "relatedto": "550e8400-e29b-41d4-a716-446655440000",
+              "relatedtosource": "urn:async-source:client:123",
+              "data": {
+                "type": "urn:problem-type:belgif:badRequest",
+                "href": "https://www.belgif.be/specification/rest/api-guide/problems/badRequest.html",
+                "title": "Bad Request",
+                "detail":  "The input message is incorrect",
+                "instance": "urn:uuid:987654-1234-1235-4567489798",
+                "issues": [
+                  {
+                    "type": "urn:problem-type:belgif:input-validation:schemaViolation",
+                    "detail": "value 123 of invitees[0] is not of type string",
+                    "in": "body",
+                    "name": "invitees[0]",
+                    "value": 123
+                  }
+                ]
+              }
+            }
+    "be.belgif.example.meeting.v3.meetings.notify.invited":
+      payload:
+        schema:
+          $ref: '#/components/schemas/MeetingInvitedMessage'
+    "be.belgif.example.meeting.v3.meetings.notify.canceled":
+      payload:
+        schema:
+          $ref: '#/components/schemas/MeetingCanceledMessage'
+  schemas:
+    Meeting:
+      description: A meeting
+      type: object
+      properties:
+        id:
+          type: string
+          description: Identifier of the meeting
+        invitees:
+          type: array
+          items:
+            description: "Identifier of a person"
+            type: string
+        room:
+          type: string
+        period:
+          type: object
+          properties:
+            start:
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
+          required: [start, end]
+      required: [invitees, period]
+    CreateMeetingMessage:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/AsynchronousMessageBase"
+      properties:
+        data:
+          $ref: "#/components/schemas/Meeting"
+      required: [data]
+      example:
+        {
+          "specversion": "1.0",
+          "id": "550e8400-e29b-41d4-a716-446655440000",
+          "service": "be.belgif.example.meeting.v3",
+          "type": "be.belgif.example.meeting.v3.meetings.create",
+          "source": "urn:async-source:client:123",
+          "subject": "132456",
+          "data": {
+            "invitees": ["123", "456"],
+            "period": {
+              "start": "2025-10-06T13:30:00+02:00",
+              "end": "2025-10-06T14:30:00+02:00"
+            }
+          }
+        }
+    CreateMeetingReplyMessage:
+      type: object
+      allOf:
+        # extends reply message, which adds relatedto(source) properties
+        - $ref: "#/components/schemas/AsynchronousReplyMessageBase"
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              description: Identifier of meeting that was created
+              type: string
+          required: [id]
+      required: [ data ]
+      example:
+        {
+          "specversion": "1.0",
+          "id": "123ef800-e29b-41d4-a716-546655440001",
+          "service": "be.belgif.example.meeting.v3",
+          "source": "urn:async-source:be.belgif.example",
+          "type": "be.belgif.example.meeting.v3.meetings.create.reply",
+          "relatedto": "550e8400-e29b-41d4-a716-446655440000",
+          "relatedtosource": "urn:async-source:client:123",
+          "subject": "132456",
+          "data": {
+            "id": "132456"
+          }
+        }
+    MeetingInvitedMessage:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/AsynchronousMessageBase"
+      properties:
+        data:
+          $ref: "#/components/schemas/Meeting"
+      required: [ data ]
+      example:
+        {
+          "specversion": "1.0",
+          "id": "450e8400-e29b-41d4-a716-446655440007",
+          "service": "be.belgif.example.meeting.v3",
+          "type": "be.belgif.example.meeting.v3.meetings.notify.invited",
+          "source": "urn:async-source:be.belgif.example",
+          "subject": "132456",
+          "data": {
+            "id": "132456",
+            "invitees": [ "123", "456" ],
+            "period": {
+              "start": "2025-10-06T13:30:00+02:00",
+              "end": "2025-10-06T14:30:00+02:00"
+            }
+          }
+        }
+    MeetingCanceledMessage:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/AsynchronousMessageBase"
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              description: Identifier of the meeting
+              type: string
+          required: [id]
+      required: [ data ]
+      example:
+        {
+          "specversion": "1.0",
+          "id": "650e8400-e29b-41d4-a716-446655440006",
+          "service": "be.belgif.example.meeting.v3",
+          "type": "be.belgif.example.meeting.v3.meetings.notify.canceled",
+          "source": "urn:async-source:be.belgif.example",
+          "subject": "132456",
+          "data": {
+            "id": "132456",
+          }
+        }
+
+    ### schemas adapted from cloudevents-v1.yaml, replacing `nullable: true` by `type: [..., "null"]` ###
+
+    AsynchronousMessageBase: # extend this schema with allOf to define schemas for specific events, with constraints on data/data_base64 and type
+      type: object
+      description: Context attributes of an AsynchronousMessage in CloudEvent JSON format.
+      # An AsynchronousMessage is an extension of the CloudEvent format, also allowing other async exchanges than events.
+      properties:
+        specversion:
+          type: string
+          minLength: 1
+          description: The version of the CloudEvents specification used to represent the message.
+          example: "1.0"
+        id:
+          type: string
+          minLength: 1
+          description: Identifies the message. Producers MUST ensure that source + id is unique for each distinct message. If a duplicate message is re-sent (e.g. due to a network error) it MAY have the same id. Consumers MAY assume that Asynchronous Messages with identical source and id are duplicates.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        type:
+          description: >
+            Type of the message.<br>
+            Often this attribute is used for routing, observability, policy enforcement, etc. 
+            The format of this is producer defined and might include information such as the version of the type.<br>
+
+            The type SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates the organization which defines the semantics of this message type.
+          type: string
+          minLength: 1
+          example: "be.belgif.example.meeting.v3.meetings.create"
+        service:
+          description: |
+            Name of the service (API) that defines the format and exchange protocol of this message.
+            Recommended to use reverse DNS notation, with the last segment being the major version number prefixed by the letter `v`.
+          type: string
+          minLength: 1
+          example: "be.belgif.example.meeting.v3"
+        source:
+          type: string
+          format: uri-reference
+          minLength: 1
+          description: >
+            Identifies the context in which the message was created.<br>
+            Often this will include information such as the type of the message source, the organization publishing the message or the process that produced the message. The exact syntax and semantics behind the data encoded in the URI is defined by the message producer.<br>
+
+            Producers MUST ensure that source + id is unique for each distinct message.<br>
+
+            An application MAY assign a unique source to each distinct producer, which makes it
+            easy to produce unique IDs since no other producer will have the same source.
+            The application MAY use UUIDs, URNs, DNS authorities or an application-specific
+            scheme to create unique source identifiers.<br>
+
+            An absolute URI is RECOMMENDED
+          example: "urn:async-source:client:123"
+        datacontenttype:
+          type: [string, "null"]
+          minLength: 1
+          description: Media type of the payload (values of data or data_base64).
+            MUST adhere to the format specified in RFC 2046.
+          default: "application/json"
+          x-ignore-rules:
+            jsn-null: allow null to comply with CloudEvents 1.0 spec
+        subject:
+          type: [string, "null"]
+          minLength: 1
+          description: Subject of the message (optional, may also be only present in payload)
+          x-ignore-rules:
+            jsn-null: allow null to comply with CloudEvents 1.0 spec
+        time:
+          type: [string, "null"]
+          format: date-time
+          description: Timestamp of when the occurrence happened. If the time of the occurrence cannot be determined then this attribute MAY be set to some other time (such as the current time) by the CloudEvents producer, however all producers for the same source MUST be consistent in this respect. In other words, either they all use the actual time of the occurrence or they all use the same algorithm to determine the value used.
+          x-ignore-rules:
+            jsn-null: allow null to comply with CloudEvents 1.0 spec
+        dataschema:
+          description: Identifies the schema that data adheres to. Incompatible changes to the schema SHOULD be reflected by a different URI.
+          type: [string, "null"]
+          minLength: 1
+          format: uri
+          x-ignore-rules:
+            jsn-null: allow null to comply with CloudEvents 1.0 spec
+      required: [ id, type, service, specversion, source ]
+
+    AsynchronousReplyMessageBase:
+      description: Context attributes for reply messages
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/AsynchronousMessageBase"
+        - properties:
+            relatedto:
+              description: The `id` of the corresponding request message
+              type: string
+              minLength: 1
+              example: "550e8400-e29b-41d4-a716-446655440000"
+            relatedtosource:
+              description: The `source` of the corresponding request message
+              type: string
+              minLength: 1
+              example: "urn:async-source:client:123"
+          required: [relatedto, relatedtosource]
+
+    AsynchronousProblemReplyMessage:
+      description: An asynchronous problem reply message
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/AsynchronousReplyMessageBase"
+        - properties:
+            data:
+              $ref: "#/components/schemas/Problem"
+          required: [data]
+      example:
+        {
+          "specversion": "1.0",
+          "id": "987654-1234-1235-4567489798",
+          "service": "be.belgif.example.meeting.v3",
+          "source": "urn:async-source:be.belgif.example",
+          "type": "be.belgif.example.meeting.v3.meetings.create.problemReply",
+          "datacontenttype": "application/problem+json",
+          "relatedto": "550e8400-e29b-41d4-a716-446655440000",
+          "relatedtosource": "urn:async-source:client:123",
+          "data": {
+            "type": "urn:problem-type:belgif:badRequest",
+            "href": "https://www.belgif.be/specification/rest/api-guide/problems/badRequest.html",
+            "title": "Bad Request",
+            "detail":  "The input message is incorrect",
+            "instance": "urn:uuid:987654-1234-1235-4567489798",
+            "issues": [
+              {
+                "type": "urn:problem-type:belgif:input-validation:schemaViolation",
+                "detail": "value 123 of invitees[0] is not of type string",
+                "in": "body",
+                "name": "invitees[0]",
+                "value": 123
+              }
+            ]
+          }
+        }
+
+    ### copied from problem-v1.yaml and adapted exclusiveMaximum/maximum ###
+    Problem:
+      description: |
+        A Problem Details object (RFC 9457).
+        
+        Additional properties specific to the problem type may be present.    
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+          description: An absolute URI that identifies the problem type
+          default: about:blank  # kept for backwards-compatibility, type will be mandatory in problem-v2
+        href:
+          type: string
+          format: uri
+          description: An absolute URI that, when dereferenced, provides human-readable documentation for the problem type (e.g. using HTML).
+        title:
+          type: string
+          description: A short summary of the problem type. Written in English and readable for engineers (usually not suited for non technical stakeholders and not localized).
+          example: Service Unavailable
+        status:
+          type: integer
+          format: int32
+          description: The HTTP status code generated by the origin server for this occurrence of the problem.
+          minimum: 400
+          exclusiveMaximum: 600
+          example: 503
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence of the problem
+        instance:
+          type: string
+          format: uri
+          description: An absolute URI that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.
+      example:
+        type: urn:problem-type:exampleOrganization:exampleProblem # "exampleOrganization" should be a short identifier for the organization that defines the problem type. "belgif" is used for problem types standardized in the Belgif REST guide
+        href: "https://www.belgif.be/specification/rest/api-guide/#standardized-problem-types" # optional, should refer to documentation of the problem type, either of a belgif standardized or a custom problem type
+        title: Description of the type of problem that occurred
+        status: 400 # HTTP response status, appropriate for the problem type
+        detail: Description of specific occurrence of the problem
+        instance: urn:uuid:123e4567-e89b-12d3-a456-426614174000

--- a/src/test/resources/meeting-asyncapi.yaml
+++ b/src/test/resources/meeting-asyncapi.yaml
@@ -38,7 +38,7 @@ channels:
 operations:
   sendMeetingMessage:
     summary: "Send messages related to meetings"
-    action: receive
+    action: send
     channel:
       $ref: '#/channels/MeetingSendChannel'
   receiveMeetingMessage:

--- a/src/test/resources/meeting-asyncapi.yaml
+++ b/src/test/resources/meeting-asyncapi.yaml
@@ -2,7 +2,7 @@ asyncapi: 3.0.0
 # !! AsyncAPI tooling can't be used for this document currently because of a problem with AsyncAPI tooling with referenced OpenAPI schemas, see https://github.com/asyncapi/openapi-schema-parser/issues/275
 info:
   title: Meeting
-  version: 3.0.0
+  version: 3.7.1
   description: |
     The meeting API allows you to manage meetings and get notifications upon meeting changes.
     This is an example API description to demonstrate using AsyncAPI for asynchronous messaging compliant with the Belgif guide.
@@ -19,14 +19,14 @@ servers:
 channels:
   MeetingSendChannel:
     summary: Channel to send meeting-related messages
-    address: be.belgif.example.meeting.v3
+    address: be.belgif.example.meeting.v3.sendQueue
     messages:
       "be.belgif.example.meeting.v3.meetings.create":
         $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.create'
   MeetingReceiveChannel:
-    summary: Channel to send meeting-related messages
-    address: be.belgif.example.meeting.v3
-    messages: #Spec defines that "Every message sent to this channel MUST be valid against one, and only one, of the message objects defined in this map."
+    summary: Channel to receive meeting-related messages
+    address: be.belgif.example.meeting.v3.receiveQueue
+    messages: # AsyncAPI spec defines that "Every message sent to this channel MUST be valid against one, and only one, of the message objects defined in this map."
       "be.belgif.example.meeting.v3.meetings.create.reply":
         $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.create.reply'
       "be.belgif.example.meeting.v3.meetings.create.problemReply":
@@ -36,16 +36,35 @@ channels:
       "be.belgif.example.meeting.v3.meetings.notify.canceled":
         $ref: '#/components/messages/be.belgif.example.meeting.v3.meetings.notify.canceled'
 operations:
-  sendMeetingMessage:
-    summary: "Send messages related to meetings"
+  # the messages referenced by each operation MUST be part of the list of messages on the channel used by the operation
+  # if omitted, the operation is expected to accept any message allowed on the channel
+  createMeeting:
+    summary: "Create a meeting"
     action: send
     channel:
       $ref: '#/channels/MeetingSendChannel'
-  receiveMeetingMessage:
-    summary: "Receive messages related to meetings"
+    messages:
+      - $ref: '#/channels/MeetingSendChannel/messages/be.belgif.example.meeting.v3.meetings.create'
+    reply:
+      channel:
+        $ref: '#/channels/MeetingReceiveChannel'
+      messages:
+        - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.create.reply'
+        - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.create.problemReply'
+  notifyMeetingInvited:
+    summary: "Receive notification that you were invited to a meeting"
     action: receive
     channel:
       $ref: '#/channels/MeetingReceiveChannel'
+    messages:
+      - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.notify.invited'
+  notifyMeetingCanceled:
+    summary: "Receive notification that a meeting was canceled"
+    action: receive
+    channel:
+      $ref: '#/channels/MeetingReceiveChannel'
+    messages:
+      - $ref: '#/channels/MeetingReceiveChannel/messages/be.belgif.example.meeting.v3.meetings.notify.canceled'
 components:
   messages:
     "be.belgif.example.meeting.v3.meetings.create":

--- a/src/test/resources/meeting-messages.yaml
+++ b/src/test/resources/meeting-messages.yaml
@@ -22,11 +22,11 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          "be.belgif.example.meeting.v3.meetings.create": CreateMeetingMessage
-          "be.belgif.example.meeting.v3.meetings.create.reply": CreateMeetingReplyMessage
-          "be.belgif.example.meeting.v3.meetings.create.problemReply": CreateMeetingProblemReplyMessage
-          "be.belgif.example.meeting.v3.meetings.notify.invited": MeetingInvitedMessage
-          "be.belgif.example.meeting.v3.meetings.notify.canceled": MeetingCanceledMessage
+          "be.belgif.example.meeting.v3.meetings.create": "#/components/schemas/CreateMeetingMessage"
+          "be.belgif.example.meeting.v3.meetings.create.reply": "#/components/schemas/CreateMeetingReplyMessage"
+          "be.belgif.example.meeting.v3.meetings.create.problemReply": "#/components/schemas/CreateMeetingProblemReplyMessage"
+          "be.belgif.example.meeting.v3.meetings.notify.invited": "#/components/schemas/MeetingInvitedMessage"
+          "be.belgif.example.meeting.v3.meetings.notify.canceled": "#/components/schemas/MeetingCanceledMessage"
     Meeting:
       description: A meeting
       type: object

--- a/src/test/resources/meeting-messages.yaml
+++ b/src/test/resources/meeting-messages.yaml
@@ -10,10 +10,15 @@ paths: {}
 components:
   schemas:
     MeetingMessage:
-      description: Common parent schema of all async messages in the meeting API
-      # common parent is not needed if only using the message type schemas from AsyncAPI
-      allOf:
-        - $ref: "../../main/openapi/cloudevents/v1/cloudevents-v1.yaml#/components/schemas/AsynchronousMessageBase"
+      description: Common schema of all async messages in the meeting API
+      type: object
+      # this common parent is not needed if only referencing the specific message type from AsyncAPI
+      oneOf:
+        - $ref: "#/components/schemas/CreateMeetingMessage"
+        - $ref: "#/components/schemas/CreateMeetingReplyMessage"
+        - $ref: "#/components/schemas/CreateMeetingProblemReplyMessage"
+        - $ref: "#/components/schemas/MeetingInvitedMessage"
+        - $ref: "#/components/schemas/MeetingCanceledMessage"
       discriminator:
         propertyName: type
         mapping:
@@ -46,11 +51,11 @@ components:
               type: string
               format: date-time
           required: [start, end]
-        required: [invitees, period]
+      required: [invitees, period]
     CreateMeetingMessage:
       type: object
       allOf:
-        - $ref: "#/components/schemas/MeetingMessage"
+        - $ref: "../../main/openapi/cloudevents/v1/cloudevents-v1.yaml#/components/schemas/AsynchronousMessageBase"
       properties:
         data:
           $ref: "#/components/schemas/Meeting"
@@ -74,7 +79,6 @@ components:
     CreateMeetingReplyMessage:
       type: object
       allOf:
-        - $ref: "#/components/schemas/MeetingMessage"
         # extends reply message, which adds relatedto(source) properties
         - $ref: "../../main/openapi/cloudevents/v1/cloudevents-v1.yaml#/components/schemas/AsynchronousReplyMessageBase"
       properties:
@@ -103,7 +107,6 @@ components:
     CreateMeetingProblemReplyMessage:
       type: object
       allOf:
-        - $ref: "#/components/schemas/MeetingMessage"
         - $ref: "../../main/openapi/cloudevents/v1/cloudevents-v1.yaml#/components/schemas/AsynchronousProblemReplyMessage"
       example:
         {
@@ -135,7 +138,7 @@ components:
     MeetingInvitedMessage:
       type: object
       allOf:
-        - $ref: "#/components/schemas/MeetingMessage"
+        - $ref: "../../main/openapi/cloudevents/v1/cloudevents-v1.yaml#/components/schemas/AsynchronousMessageBase"
       properties:
         data:
           $ref: "#/components/schemas/Meeting"
@@ -160,7 +163,7 @@ components:
     MeetingCanceledMessage:
       type: object
       allOf:
-        - $ref: "#/components/schemas/MeetingMessage"
+        - $ref: "../../main/openapi/cloudevents/v1/cloudevents-v1.yaml#/components/schemas/AsynchronousMessageBase"
       properties:
         data:
           type: object


### PR DESCRIPTION
1) In `Base` schemas meant for extension using `allOf`, only use example values on individual properties without example for `data`. 
This avoids propagation of those examples to schemas for specific event types that don't define their own examples, which curently is confusing (e.g. when using SwaggerUI).

2) Use oneOf style polymorphism in the 'full' examples in the test directory. This avoids issues with multiple-inheritance.

3) split operations in the AsyncAPI, to better represent request/reply and fix minor bugs

When there are multiple messages in a channel with the same interaction pattern, it can become a bit arbitrary to split them into separate operations or not.

4) Add a merged AsyncAPI document example that works in current AsyncAPI studio

5) use URI-reference syntax in discriminator in example, compliant with latest rest-guide-validator